### PR TITLE
Feat: 알림 리스트 UI 및 API 연결

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.1'
+        classpath 'com.android.tools.build:gradle:8.6.0'
         classpath 'com.google.gms:google-services:4.4.2' //FCM 관련 설정
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.6.0" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 

--- a/lib/common/components/button.dart
+++ b/lib/common/components/button.dart
@@ -8,6 +8,8 @@ class Button extends StatelessWidget {
   final String buttonText;
   final Color? backgroundColor;
   final Color? textColor;
+  final double? width;
+  final double? height;
   final VoidCallback? onPressed;
   final bool isLoading;
   final Widget? icon;
@@ -22,15 +24,21 @@ class Button extends StatelessWidget {
     this.isLoading = false,
     this.icon,
     this.borderColor,
+    this.width,
+    this.height,
   });
 
   @override
   Widget build(BuildContext context) {
-    final buttonHeight = 50.h;
+    final buttonHeight = height ?? 50.h;
+    final buttonWidth = width ?? double.infinity;
 
     return TextButton(
       style: TextButton.styleFrom(
-        fixedSize: Size(double.infinity, buttonHeight),
+        fixedSize: Size(
+          buttonWidth,
+          buttonHeight,
+        ),
         backgroundColor: backgroundColor ?? AppColors.primary,
         foregroundColor: textColor ?? AppColors.neutralDark,
         shape: RoundedRectangleBorder(

--- a/lib/common/enums/match_type.dart
+++ b/lib/common/enums/match_type.dart
@@ -1,0 +1,8 @@
+enum MatchType {
+  start('start'),
+  finish('finish');
+
+  const MatchType(this.value);
+
+  final String value;
+}

--- a/lib/common/enums/status_type.dart
+++ b/lib/common/enums/status_type.dart
@@ -1,0 +1,8 @@
+enum StatusType {
+  accepted('ACCEPT'),
+  rejected('REJECT');
+
+  const StatusType(this.value);
+
+  final String value;
+}

--- a/lib/common/layout/main_screen.dart
+++ b/lib/common/layout/main_screen.dart
@@ -1,17 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gachtaxi_app/common/layout/default_layout.dart';
 import 'package:gachtaxi_app/domain/home/components/custom_bottom_nav_bar.dart';
 import 'package:gachtaxi_app/domain/home/view/home_screen.dart';
 import 'package:gachtaxi_app/domain/my-page/view/my_page_screen.dart';
+import 'package:gachtaxi_app/domain/notification-list/providers/unread_notification_provider.dart';
 
-class MainScreen extends StatefulWidget {
+class MainScreen extends ConsumerStatefulWidget {
   const MainScreen({super.key});
 
   @override
-  State<MainScreen> createState() => _MainScreenState();
+  ConsumerState<MainScreen> createState() => _MainScreenState();
 }
 
-class _MainScreenState extends State<MainScreen> {
+class _MainScreenState extends ConsumerState<MainScreen> {
   final PageController _pageController = PageController();
   int _selectedIndex = 0;
   int previousIndex = 0;
@@ -48,7 +50,13 @@ class _MainScreenState extends State<MainScreen> {
       canPop: _selectedIndex != 3,
       onPopInvokedWithResult: (didPop, result) {
         if (!didPop && _selectedIndex == 3) {
-          setState(() => _selectedIndex = previousIndex);
+          setState(() {
+            _selectedIndex = previousIndex;
+
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              ref.invalidate(unreadNotificationNotifierProvider);
+            });
+          });
         }
       },
       child: Stack(
@@ -56,7 +64,8 @@ class _MainScreenState extends State<MainScreen> {
           Offstage(
             offstage: _selectedIndex == 3,
             child: RepaintBoundary(
-                child: HomeScreen(pageController: _pageController)),
+              child: HomeScreen(pageController: _pageController),
+            ),
           ),
           Offstage(
             offstage: _selectedIndex != 3,

--- a/lib/common/model/api_response.dart
+++ b/lib/common/model/api_response.dart
@@ -4,7 +4,7 @@ part 'api_response.freezed.dart';
 part 'api_response.g.dart';
 
 @Freezed(genericArgumentFactories: true)
-class ApiResponse<T> with _$ApiResponse<T> {
+abstract class ApiResponse<T> with _$ApiResponse<T> {
   const factory ApiResponse({
     required int code,
     required String message,
@@ -12,7 +12,8 @@ class ApiResponse<T> with _$ApiResponse<T> {
   }) = _ApiResponse<T>;
 
   factory ApiResponse.fromJson(
-      Map<String, dynamic> json,
-      T Function(Object? json) fromJsonT,
-      ) => _$ApiResponseFromJson(json, fromJsonT);
+    Map<String, dynamic> json,
+    T Function(Object? json) fromJsonT,
+  ) =>
+      _$ApiResponseFromJson(json, fromJsonT);
 }

--- a/lib/common/model/pageable_model.dart
+++ b/lib/common/model/pageable_model.dart
@@ -4,7 +4,7 @@ part 'pageable_model.g.dart';
 part 'pageable_model.freezed.dart';
 
 @freezed
-class Pageable with _$Pageable {
+abstract class Pageable with _$Pageable {
   const factory Pageable({
     required int pageNumber,
     required int pageSize,

--- a/lib/domain/chat/data/models/chat_message_model.dart
+++ b/lib/domain/chat/data/models/chat_message_model.dart
@@ -5,7 +5,7 @@ part 'chat_message_model.freezed.dart';
 part 'chat_message_model.g.dart';
 
 @freezed
-class ChatMessageModel with _$ChatMessageModel {
+abstract class ChatMessageModel with _$ChatMessageModel {
   const factory ChatMessageModel({
     String? messageId,
     int? roomId,

--- a/lib/domain/chat/data/models/response/account_response.dart
+++ b/lib/domain/chat/data/models/response/account_response.dart
@@ -4,7 +4,7 @@ part 'account_response.freezed.dart';
 part 'account_response.g.dart';
 
 @freezed
-class AccountResponse with _$AccountResponse {
+abstract class AccountResponse with _$AccountResponse {
   const factory AccountResponse({
     required int userId,
     required int studentNumber,

--- a/lib/domain/chat/data/models/response/chat_member_count_response.dart
+++ b/lib/domain/chat/data/models/response/chat_member_count_response.dart
@@ -5,7 +5,7 @@ part 'chat_member_count_response.freezed.dart';
 part 'chat_member_count_response.g.dart';
 
 @freezed
-class ChatMemberCountResponse with _$ChatMemberCountResponse {
+abstract class ChatMemberCountResponse with _$ChatMemberCountResponse {
   const factory ChatMemberCountResponse({
     required int roomId,
     required int totalParticipantCount,

--- a/lib/domain/chat/data/models/response/chat_member_response.dart
+++ b/lib/domain/chat/data/models/response/chat_member_response.dart
@@ -4,7 +4,7 @@ part 'chat_member_response.freezed.dart';
 part 'chat_member_response.g.dart';
 
 @freezed
-class ChatMemberResponse with _$ChatMemberResponse {
+abstract class ChatMemberResponse with _$ChatMemberResponse {
   const factory ChatMemberResponse({
     required int memberId,
     required String nickName,

--- a/lib/domain/chat/data/models/response/chat_message_response.dart
+++ b/lib/domain/chat/data/models/response/chat_message_response.dart
@@ -6,7 +6,7 @@ part 'chat_message_response.freezed.dart';
 part 'chat_message_response.g.dart';
 
 @freezed
-class ChatMessageResponse with _$ChatMessageResponse {
+abstract class ChatMessageResponse with _$ChatMessageResponse {
   const factory ChatMessageResponse({
     required int memberId,
     DateTime? disconnectedAt,

--- a/lib/domain/home/model/auto-matching/auto_matching_request_model.dart
+++ b/lib/domain/home/model/auto-matching/auto_matching_request_model.dart
@@ -4,7 +4,7 @@ part 'auto_matching_request_model.freezed.dart';
 part 'auto_matching_request_model.g.dart';
 
 @freezed
-class AutoMatchingRequest with _$AutoMatchingRequest {
+abstract class AutoMatchingRequest with _$AutoMatchingRequest {
   const factory AutoMatchingRequest({
     required String startPoint,
     required String destinationPoint,

--- a/lib/domain/home/model/blacklist/blacklist_model.dart
+++ b/lib/domain/home/model/blacklist/blacklist_model.dart
@@ -5,7 +5,7 @@ part 'blacklist_model.freezed.dart';
 part 'blacklist_model.g.dart';
 
 @freezed
-class Blacklist with _$Blacklist {
+abstract class Blacklist with _$Blacklist {
   const factory Blacklist({
     required int receiverId,
     required String receiverNickname,

--- a/lib/domain/home/model/blacklist/blacklist_response_model.dart
+++ b/lib/domain/home/model/blacklist/blacklist_response_model.dart
@@ -6,7 +6,7 @@ part 'blacklist_response_model.freezed.dart';
 part 'blacklist_response_model.g.dart';
 
 @freezed
-class BlacklistResponse with _$BlacklistResponse {
+abstract class BlacklistResponse with _$BlacklistResponse {
   const factory BlacklistResponse({
     required List<Blacklist> blacklist,
     required Pageable pageable,

--- a/lib/domain/home/model/friend/friend_model.dart
+++ b/lib/domain/home/model/friend/friend_model.dart
@@ -5,7 +5,7 @@ part 'friend_model.freezed.dart';
 part 'friend_model.g.dart';
 
 @freezed
-class Friend with _$Friend {
+abstract class Friend with _$Friend {
   const factory Friend({
     required int friendsId,
     required String friendsNickName,

--- a/lib/domain/home/model/friend/friend_response_model.dart
+++ b/lib/domain/home/model/friend/friend_response_model.dart
@@ -6,7 +6,7 @@ part 'friend_response_model.freezed.dart';
 part 'friend_response_model.g.dart';
 
 @freezed
-class FriendResponse with _$FriendResponse {
+abstract class FriendResponse with _$FriendResponse {
   const factory FriendResponse({
     required List<Friend> response,
     required Pageable pageable,

--- a/lib/domain/home/model/manual-matching/manual_matching_response_model.dart
+++ b/lib/domain/home/model/manual-matching/manual_matching_response_model.dart
@@ -6,7 +6,7 @@ part 'manual_matching_response_model.freezed.dart';
 part 'manual_matching_response_model.g.dart';
 
 @freezed
-class MatchingData with _$MatchingData {
+abstract class MatchingData with _$MatchingData {
   const factory MatchingData({
     required List<MatchingRoom> rooms,
     required Pageable pageable,

--- a/lib/domain/home/model/manual-matching/manual_matching_room_model.dart
+++ b/lib/domain/home/model/manual-matching/manual_matching_room_model.dart
@@ -4,7 +4,7 @@ part 'manual_matching_room_model.freezed.dart';
 part 'manual_matching_room_model.g.dart';
 
 @freezed
-class MatchingRoom with _$MatchingRoom {
+abstract class MatchingRoom with _$MatchingRoom {
   const factory MatchingRoom({
     required int roomId,
     required int chattingRoomId,

--- a/lib/domain/home/shared/notifier_icon.dart
+++ b/lib/domain/home/shared/notifier_icon.dart
@@ -1,32 +1,57 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:gachtaxi_app/common/util/slide_page_route.dart';
+import 'package:gachtaxi_app/domain/notification-list/providers/unread_notification_provider.dart';
+import 'package:gachtaxi_app/domain/notification-list/view/notification_list_screen.dart';
 
-class NotifierIcon extends StatelessWidget {
+class NotifierIcon extends ConsumerWidget {
   const NotifierIcon({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final unreadNotiState = ref.watch(unreadNotificationNotifierProvider);
+
     return Stack(
       children: [
         IconButton(
-            onPressed: () {},
+            onPressed: () async {
+              await Navigator.push(
+                context,
+                SlidePageRoute(
+                  screen: const NotificationListScreen(),
+                ),
+              );
+
+              ref.invalidate(unreadNotificationNotifierProvider);
+            },
             icon: SvgPicture.asset(
               'assets/icons/notification_icon.svg',
               width: 20,
               height: 24,
             )),
-        Positioned(
-          top: 10,
-          right: 12,
-          child: Container(
-            width: 10,
-            height: 10,
-            alignment: Alignment.center,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(10),
-              color: Color(0xFFFF3636),
-            ),
-          ),
+        unreadNotiState.when(
+          data: (data) {
+            if (data.data!.unreadCount > 0) {
+              return Positioned(
+                top: 10,
+                right: 12,
+                child: Container(
+                  width: 10,
+                  height: 10,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10),
+                    color: Color(0xFFFF3636),
+                  ),
+                ),
+              );
+            } else {
+              return const SizedBox.shrink();
+            }
+          },
+          loading: () => const SizedBox.shrink(),
+          error: (e, s) => const SizedBox.shrink(),
         ),
       ],
     );

--- a/lib/domain/matching-waiting/view/matching_waiting_screen.dart
+++ b/lib/domain/matching-waiting/view/matching_waiting_screen.dart
@@ -89,7 +89,7 @@ class _MatchingWaitingScreenState extends ConsumerState<MatchingWaitingScreen> {
 
 Widget _buildLoadingScreen() {
   return DefaultLayout(
-    hasAppBar: true,
+    hasAppBar: false,
     child: SafeArea(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/domain/my-page/model/my-info/my_info_model.dart
+++ b/lib/domain/my-page/model/my-info/my_info_model.dart
@@ -4,7 +4,7 @@ part 'my_info_model.freezed.dart';
 part 'my_info_model.g.dart';
 
 @freezed
-class UserData with _$UserData {
+abstract class UserData with _$UserData {
   const factory UserData({
     required int userId,
     required int studentNumber,

--- a/lib/domain/my-page/model/notice/notices_model.dart
+++ b/lib/domain/my-page/model/notice/notices_model.dart
@@ -5,7 +5,7 @@ part 'notices_model.freezed.dart';
 part 'notices_model.g.dart';
 
 @freezed
-class NoticesData with _$NoticesData {
+abstract class NoticesData with _$NoticesData {
   const factory NoticesData({
     required List<Notice> notices,
     required Pageable pageable,
@@ -16,7 +16,7 @@ class NoticesData with _$NoticesData {
 }
 
 @freezed
-class Notice with _$Notice {
+abstract class Notice with _$Notice {
   const factory Notice({
     required int noticeId,
     required String title,

--- a/lib/domain/notification-list/model/notification_list_model.dart
+++ b/lib/domain/notification-list/model/notification_list_model.dart
@@ -5,7 +5,7 @@ part 'notification_list_model.freezed.dart';
 part 'notification_list_model.g.dart';
 
 @freezed
-class NotificationListData with _$NotificationListData {
+abstract class NotificationListData with _$NotificationListData {
   const factory NotificationListData({
     required List<NotificationModel> response,
     required Pageable pageable,
@@ -58,7 +58,7 @@ sealed class NotificationModel with _$NotificationModel {
 }
 
 @freezed
-class MatchPayload with _$MatchPayload {
+abstract class MatchPayload with _$MatchPayload {
   const factory MatchPayload({
     required String startLocationName,
     required String endLocationName,
@@ -69,7 +69,7 @@ class MatchPayload with _$MatchPayload {
 }
 
 @freezed
-class FriendRequestPayload with _$FriendRequestPayload {
+abstract class FriendRequestPayload with _$FriendRequestPayload {
   const factory FriendRequestPayload({
     required String status,
     String? profilePicture,
@@ -81,7 +81,7 @@ class FriendRequestPayload with _$FriendRequestPayload {
 }
 
 @freezed
-class MatchingRequestPayload with _$MatchingRequestPayload {
+abstract class MatchingRequestPayload with _$MatchingRequestPayload {
   const factory MatchingRequestPayload({
     required String senderNickname,
     String? profilePicture,

--- a/lib/domain/notification-list/model/notification_list_model.dart
+++ b/lib/domain/notification-list/model/notification_list_model.dart
@@ -72,6 +72,7 @@ class MatchPayload with _$MatchPayload {
 class FriendRequestPayload with _$FriendRequestPayload {
   const factory FriendRequestPayload({
     required String status,
+    String? profilePicture,
     required int senderId,
   }) = _FriendRequestPayload;
 
@@ -83,6 +84,7 @@ class FriendRequestPayload with _$FriendRequestPayload {
 class MatchingRequestPayload with _$MatchingRequestPayload {
   const factory MatchingRequestPayload({
     required String senderNickname,
+    String? profilePicture,
     required int matchingRoomId,
   }) = _MatchingRequestPayload;
 

--- a/lib/domain/notification-list/model/notification_list_model.dart
+++ b/lib/domain/notification-list/model/notification_list_model.dart
@@ -1,0 +1,91 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:gachtaxi_app/common/model/pageable_model.dart';
+
+part 'notification_list_model.freezed.dart';
+part 'notification_list_model.g.dart';
+
+@freezed
+class NotificationListData with _$NotificationListData {
+  const factory NotificationListData({
+    required List<NotificationModel> response,
+    required Pageable pageable,
+  }) = _NotificationListData;
+
+  factory NotificationListData.fromJson(Map<String, dynamic> json) =>
+      _$NotificationListDataFromJson(json);
+}
+
+@freezed
+sealed class NotificationModel with _$NotificationModel {
+  const factory NotificationModel.matchStart({
+    required String notificationId,
+    required int receiverId,
+    required String content,
+    required MatchPayload payload,
+    required String createdAt,
+    @Default('MATCH_START') String type,
+  }) = MatchStartNotification;
+
+  const factory NotificationModel.matchFinished({
+    required String notificationId,
+    required int receiverId,
+    required String content,
+    required MatchPayload payload,
+    required String createdAt,
+    @Default('MATCH_FINISHED') String type,
+  }) = MatchFinishedNotification;
+
+  const factory NotificationModel.friendRequest({
+    required String notificationId,
+    required int receiverId,
+    required String content,
+    required FriendRequestPayload payload,
+    required String createdAt,
+    @Default('FRIEND_REQUEST') String type,
+  }) = FriendRequestNotification;
+
+  const factory NotificationModel.matchInvite({
+    required String notificationId,
+    required int receiverId,
+    required String content,
+    required MatchingRequestPayload payload,
+    required String createdAt,
+    @Default('MATCH_INVITE') String type,
+  }) = MatchInviteNotification;
+
+  factory NotificationModel.fromJson(Map<String, dynamic> json) =>
+      _$NotificationModelFromJson(json);
+}
+
+@freezed
+class MatchPayload with _$MatchPayload {
+  const factory MatchPayload({
+    required String startLocationName,
+    required String endLocationName,
+  }) = _MatchPayload;
+
+  factory MatchPayload.fromJson(Map<String, dynamic> json) =>
+      _$MatchPayloadFromJson(json);
+}
+
+@freezed
+class FriendRequestPayload with _$FriendRequestPayload {
+  const factory FriendRequestPayload({
+    required String status, // You can use an enum if desired
+    required int senderId,
+  }) = _FriendRequestPayload;
+
+  factory FriendRequestPayload.fromJson(Map<String, dynamic> json) =>
+      _$FriendRequestPayloadFromJson(json);
+}
+
+@freezed
+class MatchingRequestPayload with _$MatchingRequestPayload {
+  const factory MatchingRequestPayload({
+    required String senderNickname,
+    required int matchingRoomId,
+  }) = _MatchingRequestPayload;
+
+  factory MatchingRequestPayload.fromJson(Map<String, dynamic> json) =>
+      _$MatchingRequestPayloadFromJson(json);
+}

--- a/lib/domain/notification-list/model/notification_list_model.dart
+++ b/lib/domain/notification-list/model/notification_list_model.dart
@@ -71,7 +71,7 @@ class MatchPayload with _$MatchPayload {
 @freezed
 class FriendRequestPayload with _$FriendRequestPayload {
   const factory FriendRequestPayload({
-    required String status, // You can use an enum if desired
+    required String status,
     required int senderId,
   }) = _FriendRequestPayload;
 

--- a/lib/domain/notification-list/model/unread_notification_model.dart
+++ b/lib/domain/notification-list/model/unread_notification_model.dart
@@ -4,7 +4,7 @@ part 'unread_notification_model.freezed.dart';
 part 'unread_notification_model.g.dart';
 
 @freezed
-class UnreadNotificationModel with _$UnreadNotificationModel {
+abstract class UnreadNotificationModel with _$UnreadNotificationModel {
   const factory UnreadNotificationModel({
     required int unreadCount,
     required bool hasUnreadNotifications,

--- a/lib/domain/notification-list/model/unread_notification_model.dart
+++ b/lib/domain/notification-list/model/unread_notification_model.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'unread_notification_model.freezed.dart';
+part 'unread_notification_model.g.dart';
+
+@freezed
+class UnreadNotificationModel with _$UnreadNotificationModel {
+  const factory UnreadNotificationModel({
+    required int unreadCount,
+    required bool hasUnreadNotifications,
+  }) = _UnreadNotificationModel;
+
+  factory UnreadNotificationModel.fromJson(Map<String, dynamic> json) =>
+      _$UnreadNotificationModelFromJson(json);
+}

--- a/lib/domain/notification-list/providers/manual_matching_invite_provider.dart
+++ b/lib/domain/notification-list/providers/manual_matching_invite_provider.dart
@@ -23,7 +23,7 @@ class ManualMatchingInviteNotifier extends _$ManualMatchingInviteNotifier {
           ? e.response?.data['message'] ?? '알 수 없는 서버 오류'
           : e.toString();
       state = AsyncError(Exception(message), st);
-      rethrow; // catch(e)에서 .toString()을 사용 가능하게 하기 위해 rethrow 유지
+      rethrow;
     }
   }
 }

--- a/lib/domain/notification-list/providers/manual_matching_invite_provider.dart
+++ b/lib/domain/notification-list/providers/manual_matching_invite_provider.dart
@@ -1,0 +1,29 @@
+import 'package:dio/dio.dart';
+import 'package:gachtaxi_app/common/model/api_response.dart';
+import 'package:gachtaxi_app/domain/notification-list/services/manual_matching_invite_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'manual_matching_invite_provider.g.dart';
+
+@riverpod
+class ManualMatchingInviteNotifier extends _$ManualMatchingInviteNotifier {
+  @override
+  Future<ApiResponse?> build() async {
+    return null;
+  }
+
+  Future<void> accept(int matchingRoomId, String notificationId) async {
+    final service = ManualMatchingInviteService();
+    state = const AsyncLoading();
+    try {
+      final res = await service.accept(matchingRoomId, notificationId);
+      state = AsyncData(res);
+    } catch (e, st) {
+      final message = e is DioException
+          ? e.response?.data['message'] ?? '알 수 없는 서버 오류'
+          : e.toString();
+      state = AsyncError(Exception(message), st);
+      rethrow; // catch(e)에서 .toString()을 사용 가능하게 하기 위해 rethrow 유지
+    }
+  }
+}

--- a/lib/domain/notification-list/providers/notification_list_provider.dart
+++ b/lib/domain/notification-list/providers/notification_list_provider.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:gachtaxi_app/common/model/api_response.dart';
-import 'package:gachtaxi_app/common/model/pageable_model.dart';
 import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
 import 'package:gachtaxi_app/domain/notification-list/services/notification_list_service_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';

--- a/lib/domain/notification-list/providers/notification_list_provider.dart
+++ b/lib/domain/notification-list/providers/notification_list_provider.dart
@@ -1,0 +1,143 @@
+import 'package:gachtaxi_app/common/model/api_response.dart';
+import 'package:gachtaxi_app/common/model/pageable_model.dart';
+import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
+import 'package:gachtaxi_app/domain/notification-list/services/notification_list_service_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notification_list_provider.g.dart';
+
+final mockNotificationListData = NotificationListData(
+  response: [
+    MatchStartNotification(
+      notificationId: "1",
+      receiverId: 101,
+      content: "곧 매칭 시간이에요",
+      payload: MatchPayload(
+        startLocationName: "서울역",
+        endLocationName: "강남역",
+      ),
+      createdAt: "2025-05-22T12:00:00Z",
+    ),
+    MatchFinishedNotification(
+      notificationId: "2",
+      receiverId: 101,
+      content: "매칭이 종료되었어요",
+      payload: MatchPayload(
+        startLocationName: "서울역",
+        endLocationName: "강남역",
+      ),
+      createdAt: "2025-07-04T13:00:00Z",
+    ),
+    FriendRequestNotification(
+      notificationId: "3",
+      receiverId: 101,
+      content: "닉네임님이 친구 요청을 보냈습니다.",
+      payload: FriendRequestPayload(
+        status: "PENDING",
+        senderId: 202,
+      ),
+      createdAt: "2025-07-01T14:00:00Z",
+    ),
+    MatchInviteNotification(
+      notificationId: "4",
+      receiverId: 101,
+      content: "닉네임님이 매칭방에 초대했습니다.",
+      payload: MatchingRequestPayload(
+        senderNickname: "닉네임",
+        matchingRoomId: 303,
+      ),
+      createdAt: "2025-07-02T15:00:00Z",
+    ),
+    MatchInviteNotification(
+      notificationId: "4",
+      receiverId: 101,
+      content: "닉네임님이 매칭방에 초대했습니다.",
+      payload: MatchingRequestPayload(
+        senderNickname: "닉네임",
+        matchingRoomId: 303,
+      ),
+      createdAt: "2025-03-15T15:00:00Z",
+    ),
+  ],
+  pageable: Pageable(
+    pageNumber: 0,
+    pageSize: 5,
+    numberOfElements: 4,
+    isLast: true,
+  ),
+);
+
+final mockNotificationListResponse = ApiResponse<NotificationListData>(
+  code: 200,
+  message: "성공",
+  data: mockNotificationListData,
+);
+
+@riverpod
+class NotificationListNotifier extends _$NotificationListNotifier {
+  final int _pageSize = 5;
+  int _currentPage = 0;
+  bool _hasMore = true;
+  bool _isFetchingMore = false;
+
+  @override
+  Future<ApiResponse<NotificationListData>> build() async {
+    _currentPage = 0;
+    _hasMore = true;
+    return await _fetchPage(_currentPage);
+
+    // await Future.delayed(const Duration(milliseconds: 500)); // 로딩 흉내
+    // return mockNotificationListResponse;
+  }
+
+  Future<ApiResponse<NotificationListData>> _fetchPage(int page) async {
+    final service = ref.read(notificationListServiceProvider);
+    return await service.fetchNotificationService(page, _pageSize);
+  }
+
+  Future<void> fetchMore() async {
+    if (_isFetchingMore || !_hasMore) return;
+    _isFetchingMore = true;
+
+    try {
+      final nextPage = _currentPage + 1;
+      final nextResponse = await _fetchPage(nextPage);
+      final current = state.valueOrNull;
+
+      final updatedList = [
+        ...?current?.data?.response,
+        ...?nextResponse.data?.response,
+      ];
+
+      _hasMore = !nextResponse.data!.pageable.isLast;
+      _currentPage = nextPage;
+
+      final merged = ApiResponse(
+        code: nextResponse.code,
+        message: nextResponse.message,
+        data: NotificationListData(
+          response: updatedList,
+          pageable: nextResponse.data!.pageable,
+        ),
+      );
+
+      state = AsyncData(merged);
+    } catch (e, stack) {
+      state = AsyncError(e, stack);
+    } finally {
+      _isFetchingMore = false;
+    }
+  }
+
+  Future<void> refresh() async {
+    _currentPage = 0;
+    _hasMore = true;
+
+    try {
+      final response = await _fetchPage(0);
+      state = AsyncData(response);
+    } catch (e, stack) {
+      state = AsyncError(e, stack);
+    }
+  }
+}

--- a/lib/domain/notification-list/providers/unread_notification_provider.dart
+++ b/lib/domain/notification-list/providers/unread_notification_provider.dart
@@ -1,0 +1,19 @@
+import 'package:gachtaxi_app/common/model/api_response.dart';
+import 'package:gachtaxi_app/domain/notification-list/model/unread_notification_model.dart';
+import 'package:gachtaxi_app/domain/notification-list/services/unread_notification_service_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'unread_notification_provider.g.dart';
+
+@riverpod
+class UnreadNotificationNotifier extends _$UnreadNotificationNotifier {
+  @override
+  Future<ApiResponse<UnreadNotificationModel>> build() async {
+    return await _fetchNoti();
+  }
+
+  Future<ApiResponse<UnreadNotificationModel>> _fetchNoti() async {
+    final service = ref.read(unreadNotificationServiceProvider);
+    return await service.unreadNotificationService();
+  }
+}

--- a/lib/domain/notification-list/services/manaul_matching_invite_service_provider.dart
+++ b/lib/domain/notification-list/services/manaul_matching_invite_service_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gachtaxi_app/domain/notification-list/services/manual_matching_invite_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'manaul_matching_invite_service_provider.g.dart';
+
+@riverpod
+ManualMatchingInviteService manualMatchingInviteService(Ref ref) {
+  return ManualMatchingInviteService();
+}

--- a/lib/domain/notification-list/services/manual_matching_invite_service.dart
+++ b/lib/domain/notification-list/services/manual_matching_invite_service.dart
@@ -1,0 +1,26 @@
+import 'package:dio/dio.dart';
+import 'package:gachtaxi_app/common/enums/status_type.dart';
+import 'package:gachtaxi_app/common/model/api_response.dart';
+import 'package:gachtaxi_app/common/util/api_client.dart';
+
+class ManualMatchingInviteService {
+  Future<ApiResponse> accept(int matchingRoomId, String notificationId) async {
+    const String path = '/api/matching/manual/invite/reply';
+    final uri = Uri.parse(path);
+
+    try {
+      final res = await ApiClient.post(uri, body: {
+        "matchingRoomId": matchingRoomId,
+        "notificationId": notificationId,
+        "status": StatusType.accepted.value,
+      });
+
+      return res;
+    } on DioException catch (e) {
+      final message = e.response?.data['message'] ?? '매칭 초대 수락 실패';
+      throw Exception(message);
+    } catch (e) {
+      throw Exception('매칭 초대 수락 중 알 수 없는 오류가 발생했습니다.');
+    }
+  }
+}

--- a/lib/domain/notification-list/services/notification_list_service.dart
+++ b/lib/domain/notification-list/services/notification_list_service.dart
@@ -3,12 +3,12 @@ import 'package:gachtaxi_app/common/util/api_client.dart';
 import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
 
 class NotificationListService {
+  final path = '/api/notifications';
+
   Future<ApiResponse<NotificationListData>> fetchNotificationService(
     int pageNum,
     int pageSize,
   ) async {
-    final path = '/api/notifications';
-
     final uri = Uri.parse(path).replace(queryParameters: {
       "pageNum": pageNum.toString(),
       "pageSize": pageSize.toString(),
@@ -17,12 +17,28 @@ class NotificationListService {
     final response = await ApiClient.get(uri);
 
     if (response.code == 200 && response.data is Map<String, dynamic>) {
-      return ApiResponse.fromJson(
-        Map<String, dynamic>.from(response.data),
-        (json) => NotificationListData.fromJson(json as Map<String, dynamic>),
+      final data =
+          NotificationListData.fromJson(response.data as Map<String, dynamic>);
+      return ApiResponse(
+        code: 200,
+        message: "성공",
+        data: data,
       );
     } else {
       throw Exception("알림 리스트 조회 실패");
+    }
+  }
+
+  Future<ApiResponse> deleteNotificationService(String notificationId) async {
+    final uri = Uri.parse('$path/$notificationId');
+
+    final response = await ApiClient.delete(uri);
+
+    if (response.code == 200) {
+      return ApiResponse(
+          code: response.code, message: response.message, data: {});
+    } else {
+      throw Exception("알림 개별 삭제 실패: ${response.message}");
     }
   }
 }

--- a/lib/domain/notification-list/services/notification_list_service.dart
+++ b/lib/domain/notification-list/services/notification_list_service.dart
@@ -1,0 +1,28 @@
+import 'package:gachtaxi_app/common/model/api_response.dart';
+import 'package:gachtaxi_app/common/util/api_client.dart';
+import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
+
+class NotificationListService {
+  Future<ApiResponse<NotificationListData>> fetchNotificationService(
+    int pageNum,
+    int pageSize,
+  ) async {
+    final path = '/api/notifications';
+
+    final uri = Uri.parse(path).replace(queryParameters: {
+      "pageNum": pageNum.toString(),
+      "pageSize": pageSize.toString(),
+    });
+
+    final response = await ApiClient.get(uri);
+
+    if (response.code == 200 && response.data is Map<String, dynamic>) {
+      return ApiResponse.fromJson(
+        Map<String, dynamic>.from(response.data),
+        (json) => NotificationListData.fromJson(json as Map<String, dynamic>),
+      );
+    } else {
+      throw Exception("알림 리스트 조회 실패");
+    }
+  }
+}

--- a/lib/domain/notification-list/services/notification_list_service_provider.dart
+++ b/lib/domain/notification-list/services/notification_list_service_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gachtaxi_app/domain/notification-list/services/notification_list_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notification_list_service_provider.g.dart';
+
+@riverpod
+NotificationListService notificationListService(Ref ref) {
+  return NotificationListService();
+}

--- a/lib/domain/notification-list/services/unread_notification_service.dart
+++ b/lib/domain/notification-list/services/unread_notification_service.dart
@@ -1,0 +1,21 @@
+import 'package:gachtaxi_app/common/model/api_response.dart';
+import 'package:gachtaxi_app/common/util/api_client.dart';
+import 'package:gachtaxi_app/domain/notification-list/model/unread_notification_model.dart';
+
+class UnreadNotificationService {
+  Future<ApiResponse<UnreadNotificationModel>>
+      unreadNotificationService() async {
+    final path = '/api/notifications/unread';
+
+    final uri = Uri.parse(path);
+
+    final response = await ApiClient.get(uri);
+
+    if (response.code == 200 && response.data is Map<String, dynamic>) {
+      return ApiResponse(
+          code: response.code, message: response.message, data: response.data);
+    } else {
+      throw Exception("읽지않은 알림 받아오기 실패");
+    }
+  }
+}

--- a/lib/domain/notification-list/services/unread_notification_service_provider.dart
+++ b/lib/domain/notification-list/services/unread_notification_service_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gachtaxi_app/domain/notification-list/services/unread_notification_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'unread_notification_service_provider.g.dart';
+
+@riverpod
+UnreadNotificationService unreadNotificationService(Ref ref) {
+  return UnreadNotificationService();
+}

--- a/lib/domain/notification-list/strategy/friend_request_notification_strategy.dart
+++ b/lib/domain/notification-list/strategy/friend_request_notification_strategy.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:gachtaxi_app/common/components/button.dart';
+import 'package:gachtaxi_app/common/constants/colors.dart';
+import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
+import 'package:gachtaxi_app/domain/notification-list/strategy/notification_list_ui_strategy.dart';
+
+class FriendRequestNotificationStrategy implements NotificationUiStrategy {
+  @override
+  Widget buildTile(BuildContext context, NotificationModel model) {
+    final friendRequest = model as FriendRequestNotification;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 16,
+      ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          vertical: 8,
+        ),
+        decoration: const BoxDecoration(
+          border: Border(
+            bottom: BorderSide(
+              color: AppColors.singleGray,
+              width: 1,
+            ),
+          ),
+        ),
+        child: ListTile(
+          contentPadding: EdgeInsets.zero,
+          leading: SvgPicture.asset(
+            'assets/icons/profile_on_icon.svg',
+            width: 48,
+            height: 48,
+          ),
+          title: Text(friendRequest.content,
+              style: TextStyle(color: Colors.white)),
+          trailing: Button(
+            buttonText: '수락',
+            width: 71,
+            height: 31,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/domain/notification-list/strategy/friend_request_notification_strategy.dart
+++ b/lib/domain/notification-list/strategy/friend_request_notification_strategy.dart
@@ -30,11 +30,21 @@ class FriendRequestNotificationStrategy implements NotificationUiStrategy {
         ),
         child: ListTile(
           contentPadding: EdgeInsets.zero,
-          leading: SvgPicture.asset(
-            'assets/icons/profile_on_icon.svg',
-            width: 48,
-            height: 48,
-          ),
+          leading: (friendRequest.payload.profilePicture != null)
+              ? ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Image.network(
+                    friendRequest.payload.profilePicture!,
+                    width: 48,
+                    height: 48,
+                    fit: BoxFit.cover,
+                  ),
+                )
+              : SvgPicture.asset(
+                  'assets/icons/profile_on_icon.svg',
+                  width: 48,
+                  height: 48,
+                ),
           title: Text(friendRequest.content,
               style: TextStyle(color: Colors.white)),
           trailing: Button(

--- a/lib/domain/notification-list/strategy/friend_request_notification_strategy.dart
+++ b/lib/domain/notification-list/strategy/friend_request_notification_strategy.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:gachtaxi_app/common/components/button.dart';
 import 'package:gachtaxi_app/common/constants/colors.dart';
@@ -7,7 +8,8 @@ import 'package:gachtaxi_app/domain/notification-list/strategy/notification_list
 
 class FriendRequestNotificationStrategy implements NotificationUiStrategy {
   @override
-  Widget buildTile(BuildContext context, NotificationModel model) {
+  Widget buildTile(
+      BuildContext context, NotificationModel model, WidgetRef ref) {
     final friendRequest = model as FriendRequestNotification;
 
     return Padding(

--- a/lib/domain/notification-list/strategy/match_base_notification_strategy.dart
+++ b/lib/domain/notification-list/strategy/match_base_notification_strategy.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:gachtaxi_app/common/constants/colors.dart';
 import 'package:gachtaxi_app/common/enums/match_type.dart';
@@ -12,7 +13,8 @@ class MatchBaseNotificationStrategy implements NotificationUiStrategy {
   MatchBaseNotificationStrategy({required this.matchType});
 
   @override
-  Widget buildTile(BuildContext context, NotificationModel model) {
+  Widget buildTile(
+      BuildContext context, NotificationModel model, WidgetRef ref) {
     final String iconPath;
     final String content;
     final String createdAt;

--- a/lib/domain/notification-list/strategy/match_base_notification_strategy.dart
+++ b/lib/domain/notification-list/strategy/match_base_notification_strategy.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:gachtaxi_app/common/constants/colors.dart';
+import 'package:gachtaxi_app/common/enums/match_type.dart';
+import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
+import 'package:gachtaxi_app/domain/notification-list/strategy/notification_list_ui_strategy.dart';
+import 'package:intl/intl.dart';
+
+class MatchBaseNotificationStrategy implements NotificationUiStrategy {
+  final MatchType matchType;
+
+  MatchBaseNotificationStrategy({required this.matchType});
+
+  @override
+  Widget buildTile(BuildContext context, NotificationModel model) {
+    final String iconPath;
+    final String content;
+    final String createdAt;
+
+    if (matchType == MatchType.start && model is MatchStartNotification) {
+      iconPath = 'assets/icons/taxi_on_icon.svg';
+      content = model.content;
+      createdAt = model.createdAt;
+    } else if (matchType == MatchType.finish &&
+        model is MatchFinishedNotification) {
+      iconPath = 'assets/icons/taxi_off_icon.svg';
+      content = model.content;
+      createdAt = model.createdAt;
+    } else {
+      return const SizedBox.shrink(); // 혹은 에러 표시 위젯
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 16,
+        vertical: 4,
+      ),
+      child: Container(
+        // padding: const EdgeInsets.only(
+        //   bottom: 8,
+        // ),
+        decoration: const BoxDecoration(
+          border: Border(
+            bottom: BorderSide(
+              color: AppColors.singleGray,
+              width: 1,
+            ),
+          ),
+        ),
+        child: ListTile(
+          contentPadding: EdgeInsets.zero,
+          leading: SvgPicture.asset(
+            iconPath,
+            width: 32,
+            height: 32,
+          ),
+          title: Text(content, style: const TextStyle(color: Colors.white)),
+          subtitle: Text(_formatTime(createdAt),
+              style: const TextStyle(color: Colors.grey)),
+        ),
+      ),
+    );
+  }
+
+  String _formatTime(String createdAt) {
+    DateTime dateTime = DateTime.parse(createdAt).toLocal();
+    String formattedTime = DateFormat('a hh:mm', 'ko_KR').format(dateTime);
+
+    return formattedTime;
+  }
+}

--- a/lib/domain/notification-list/strategy/match_invite_notification_strategy.dart
+++ b/lib/domain/notification-list/strategy/match_invite_notification_strategy.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:gachtaxi_app/common/constants/colors.dart';
+import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
+import 'package:gachtaxi_app/domain/notification-list/strategy/notification_list_ui_strategy.dart';
+
+class MatchInviteNotificationStrategy implements NotificationUiStrategy {
+  @override
+  Widget buildTile(BuildContext context, NotificationModel model) {
+    final invite = model as MatchInviteNotification;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 16,
+        vertical: 4,
+      ),
+      child: Container(
+        // padding: const EdgeInsets.only(
+        //   bottom: 16,
+        // ),
+        decoration: const BoxDecoration(
+          border: Border(
+            bottom: BorderSide(
+              color: AppColors.singleGray,
+              width: 1,
+            ),
+          ),
+        ),
+        child: ListTile(
+          contentPadding: EdgeInsets.zero,
+          leading: SvgPicture.asset(
+            'assets/icons/taxi_on_icon.svg',
+            width: 32,
+            height: 32,
+          ),
+          title: Text(invite.content, style: TextStyle(color: Colors.white)),
+          subtitle: Text(_formatTime(invite.createdAt),
+              style: TextStyle(color: Colors.grey)),
+        ),
+      ),
+    );
+  }
+
+  String _formatTime(String createdAt) {
+    return createdAt;
+  }
+}

--- a/lib/domain/notification-list/strategy/match_invite_notification_strategy.dart
+++ b/lib/domain/notification-list/strategy/match_invite_notification_strategy.dart
@@ -1,13 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:gachtaxi_app/common/components/button.dart';
 import 'package:gachtaxi_app/common/constants/colors.dart';
+import 'package:gachtaxi_app/common/util/toast_show_utils.dart';
 import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
+import 'package:gachtaxi_app/domain/notification-list/providers/manual_matching_invite_provider.dart';
 import 'package:gachtaxi_app/domain/notification-list/strategy/notification_list_ui_strategy.dart';
 
 class MatchInviteNotificationStrategy implements NotificationUiStrategy {
   @override
-  Widget buildTile(BuildContext context, NotificationModel model) {
+  Widget buildTile(
+      BuildContext context, NotificationModel model, WidgetRef ref) {
     final invite = model as MatchInviteNotification;
+    final matchingInviteState = ref.watch(manualMatchingInviteNotifierProvider);
+    final isLoading = matchingInviteState.isLoading;
 
     return Padding(
       padding: const EdgeInsets.symmetric(
@@ -15,9 +22,6 @@ class MatchInviteNotificationStrategy implements NotificationUiStrategy {
         vertical: 4,
       ),
       child: Container(
-        // padding: const EdgeInsets.only(
-        //   bottom: 16,
-        // ),
         decoration: const BoxDecoration(
           border: Border(
             bottom: BorderSide(
@@ -33,15 +37,49 @@ class MatchInviteNotificationStrategy implements NotificationUiStrategy {
             width: 32,
             height: 32,
           ),
-          title: Text(invite.content, style: TextStyle(color: Colors.white)),
-          subtitle: Text(_formatTime(invite.createdAt),
-              style: TextStyle(color: Colors.grey)),
+          title: Text(
+            invite.content,
+            style: TextStyle(color: Colors.white),
+          ),
+          trailing: Button(
+            onPressed: () async {
+              if (isLoading) return;
+
+              try {
+                await ref
+                    .read(manualMatchingInviteNotifierProvider.notifier)
+                    .accept(
+                        invite.payload.matchingRoomId, invite.notificationId);
+
+                final current = ref.read(manualMatchingInviteNotifierProvider);
+
+                if (current.hasValue && current.value?.code == 200) {
+                  if (context.mounted) {
+                    ToastShowUtils(context: context)
+                        .showSuccess(current.value?.message ?? '수락 완료');
+                  }
+                } else if (current.hasError) {
+                  final errorMessage =
+                      current.error.toString().replaceFirst('Exception: ', '');
+                  if (context.mounted) {
+                    ToastShowUtils(context: context).showSuccess(errorMessage);
+                  }
+                }
+              } catch (e) {
+                final errorMessage =
+                    e.toString().replaceFirst('Exception: ', '');
+                if (context.mounted) {
+                  ToastShowUtils(context: context).showSuccess(errorMessage);
+                }
+              }
+            },
+            isLoading: isLoading,
+            buttonText: '수락',
+            width: 71,
+            height: 31,
+          ),
         ),
       ),
     );
-  }
-
-  String _formatTime(String createdAt) {
-    return createdAt;
   }
 }

--- a/lib/domain/notification-list/strategy/notification_list_ui_strategy.dart
+++ b/lib/domain/notification-list/strategy/notification_list_ui_strategy.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
 
 abstract class NotificationUiStrategy {
-  Widget buildTile(BuildContext context, NotificationModel model);
+  Widget buildTile(
+      BuildContext context, NotificationModel model, WidgetRef ref);
 }

--- a/lib/domain/notification-list/strategy/notification_list_ui_strategy.dart
+++ b/lib/domain/notification-list/strategy/notification_list_ui_strategy.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
+
+abstract class NotificationUiStrategy {
+  Widget buildTile(BuildContext context, NotificationModel model);
+}

--- a/lib/domain/notification-list/strategy/notification_strategy_factory.dart
+++ b/lib/domain/notification-list/strategy/notification_strategy_factory.dart
@@ -1,0 +1,19 @@
+import 'package:gachtaxi_app/common/enums/match_type.dart';
+import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
+import 'package:gachtaxi_app/domain/notification-list/strategy/friend_request_notification_strategy.dart';
+import 'package:gachtaxi_app/domain/notification-list/strategy/match_base_notification_strategy.dart';
+import 'package:gachtaxi_app/domain/notification-list/strategy/match_invite_notification_strategy.dart';
+import 'package:gachtaxi_app/domain/notification-list/strategy/notification_list_ui_strategy.dart';
+
+class NotificationUiStrategyFactory {
+  static NotificationUiStrategy getStrategy(NotificationModel model) {
+    return model.map(
+      matchStart: (_) =>
+          MatchBaseNotificationStrategy(matchType: MatchType.start),
+      matchFinished: (_) =>
+          MatchBaseNotificationStrategy(matchType: MatchType.finish),
+      friendRequest: (_) => FriendRequestNotificationStrategy(),
+      matchInvite: (_) => MatchInviteNotificationStrategy(),
+    );
+  }
+}

--- a/lib/domain/notification-list/view/notification_list_screen.dart
+++ b/lib/domain/notification-list/view/notification_list_screen.dart
@@ -111,7 +111,7 @@ class NotificationListScreen extends ConsumerWidget {
                     },
                     child: KeyedSubtree(
                       key: ValueKey(notification.notificationId),
-                      child: strategy.buildTile(context, notification),
+                      child: strategy.buildTile(context, notification, ref),
                     ),
                   );
                 }

--- a/lib/domain/notification-list/view/notification_list_screen.dart
+++ b/lib/domain/notification-list/view/notification_list_screen.dart
@@ -131,7 +131,7 @@ class NotificationListScreen extends ConsumerWidget {
 
   String _getDateGroup(String createdAt) {
     try {
-      final nowUtc = DateTime.now().toUtc();
+      final nowUtc = DateTime.now();
       final todayUtc = DateTime(nowUtc.year, nowUtc.month, nowUtc.day);
       final notificationDateLocal = DateTime.parse(createdAt).toLocal();
       final notificationDayLocal = DateTime(

--- a/lib/domain/notification-list/view/notification_list_screen.dart
+++ b/lib/domain/notification-list/view/notification_list_screen.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gachtaxi_app/common/layout/default_layout.dart';
+import 'package:gachtaxi_app/domain/notification-list/model/notification_list_model.dart';
+import 'package:gachtaxi_app/domain/notification-list/providers/notification_list_provider.dart';
+import 'package:gachtaxi_app/domain/notification-list/strategy/notification_strategy_factory.dart';
+
+class NotificationListScreen extends ConsumerWidget {
+  const NotificationListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notificationListState = ref.watch(notificationListNotifierProvider);
+
+    return DefaultLayout(
+      hasAppBar: true,
+      title: '알림',
+      child: SafeArea(
+        child: notificationListState.when(
+          data: (response) {
+            final notificationListData = response.data;
+
+            if (notificationListData == null ||
+                notificationListData.response.isEmpty) {
+              return const Center(
+                child: Text('데이터가 없습니다.'),
+              );
+            }
+
+            // 날짜별 그룹핑
+            final Map<String, List<NotificationModel>> groupedNotifications =
+                {};
+            for (final notification in notificationListData.response) {
+              final dateGroup = _getDateGroup(notification.createdAt);
+              groupedNotifications.putIfAbsent(dateGroup, () => []);
+              groupedNotifications[dateGroup]!.add(notification);
+            }
+
+            final List<_GroupOrNotification> items = [];
+            for (var group in ['오늘', '최근 7일', '최근 30일']) {
+              final notifications = groupedNotifications[group];
+              if (notifications != null && notifications.isNotEmpty) {
+                items.add(_GroupOrNotification.header(group));
+                items.addAll(notifications
+                    .map((n) => _GroupOrNotification.notification(n)));
+              }
+            }
+
+            final hasMore = !(notificationListData.pageable.isLast);
+            final itemCount = items.length + (hasMore ? 1 : 0);
+
+            return ListView.builder(
+              itemCount: itemCount,
+              itemBuilder: (context, index) {
+                if (hasMore && index == items.length) {
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    ref
+                        .read(notificationListNotifierProvider.notifier)
+                        .fetchMore();
+                  });
+                  return const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 16.0),
+                    child: Center(child: CircularProgressIndicator()),
+                  );
+                }
+
+                final item = items[index];
+                if (item.isHeader) {
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 16,
+                    ),
+                    child: Text(
+                      item.groupTitle!,
+                      style: const TextStyle(
+                        color: Colors.grey,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 16,
+                      ),
+                    ),
+                  );
+                } else {
+                  final notification = item.notification!;
+                  final strategy =
+                      NotificationUiStrategyFactory.getStrategy(notification);
+                  return KeyedSubtree(
+                    key: ValueKey(notification.notificationId),
+                    child: strategy.buildTile(context, notification),
+                  );
+                }
+              },
+            );
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, st) => Center(child: Text('오류가 발생했습니다: $e')),
+        ),
+      ),
+    );
+  }
+
+  String _getDateGroup(String createdAt) {
+    try {
+      final nowUtc = DateTime.now().toUtc();
+      final todayUtc = DateTime(nowUtc.year, nowUtc.month, nowUtc.day);
+      final notificationDateLocal = DateTime.parse(createdAt).toLocal();
+      final notificationDayLocal = DateTime(
+        notificationDateLocal.year,
+        notificationDateLocal.month,
+        notificationDateLocal.day,
+      );
+      final difference = todayUtc.difference(notificationDayLocal).inDays;
+
+      if (difference == 0) {
+        return '오늘';
+      } else if (difference < 7) {
+        return '최근 7일';
+      }
+      return '최근 30일';
+    } catch (e) {
+      return '최근 30일';
+    }
+  }
+}
+
+class _GroupOrNotification {
+  final String? groupTitle;
+  final NotificationModel? notification;
+
+  bool get isHeader => groupTitle != null;
+
+  const _GroupOrNotification.header(this.groupTitle) : notification = null;
+  const _GroupOrNotification.notification(this.notification)
+      : groupTitle = null;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   flutter_dotenv: ^5.2.1
   toastification: ^3.0.1
   json_annotation: ^4.9.0
-  freezed_annotation: ^2.4.4
+  freezed_annotation: ^3.1.0
   google_maps_flutter: ^2.10.1
   flutter_svg: ^2.0.17
   smooth_page_indicator: ^1.2.1
@@ -52,15 +52,15 @@ dependencies:
   logger: ^2.5.0
   stomp_dart_client: ^2.1.3
   flutter_secure_storage: ^9.2.4
-  firebase_core: ^3.12.1
-  firebase_messaging: ^15.2.4
-  permission_handler: ^11.4.0
+  firebase_core: ^4.0.0
+  firebase_messaging: ^16.0.0
+  permission_handler: ^12.0.1
   vibration: ^3.1.3
   flutter_native_splash: ^2.4.4
   flutter_launcher_icons: ^0.14.3
-  geolocator: ^10.1.1
+  geolocator: ^14.0.2
   kakao_flutter_sdk_user: ^1.5.1
-  google_sign_in: ^6.2.1
+  google_sign_in: ^7.1.1
 
 dev_dependencies:
   flutter_test:
@@ -73,15 +73,11 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
   riverpod_generator: ^2.6.4
-  build_runner: ^2.4.15
+  build_runner: ^2.4.6
   riverpod_lint: ^2.6.4
-  json_serializable: ^6.9.4
-  freezed: ^2.5.8
+  json_serializable: ^6.7.1
+  freezed: ^3.1.0
   url_launcher: ^6.3.1
-
-dependency_overrides:
-  analyzer: ^7.4.0
-  analyzer_plugin: ^0.13.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #44 
Close #44 


## 🚀 작업 내용
> PR에서 작업한 내용을 설명

- 알림 리스트 UI 및 API 연결 로직 작성했습니다!
- 알림 리스트 전체 가져오기, 알림 지우기, 일부 알림 수락 등의 로직 등 구현했습니다!
- 전체적인 리스트의 UI는 일전에 강혁님이 채팅방 로직 작성하실 때 사용하셨던 전략 패턴 참고했고, 내부 서비스 로직이나 로딩 처리 등을 위해 프로바이더 사용하는 형태로 구현했습니다!
- 추가적으로 안읽음 처리 관련 API는 일단 다른 스크린으로 이동할때만 재요청하도록 해두었습니다!

## 📸 스크린샷


https://github.com/user-attachments/assets/9510996d-4151-4972-9552-8fa1a754f32b

![스크린샷 2025-07-08 201117](https://github.com/user-attachments/assets/0a232c4f-c1ea-4d38-9080-6c47b29a570e)


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

- 친구요청 수락쪽은 팀장님 pr 머지되면 친구리스트 쪽 수락 api 사용하도록 하겠습니다!
- 또 현재는 기존 명세서 기준 타입 사용하는데 알림리스트 쪽 강혁님께서 수정하시면 보고 변경해서 머지하도록 할게요!
- 디자인 보면 `pending` 상태일 때 버튼 스타일이 바뀌는데 아마 이것도 팀장님 PR에 포함되어있을거라 따로 작성하진 않았습니다!
