### PR TITLE
Feat: 최신화된 자동매칭 로직 작성

### DIFF
--- a/lib/common/components/button.dart
+++ b/lib/common/components/button.dart
@@ -14,6 +14,7 @@ class Button extends StatelessWidget {
   final bool isLoading;
   final Widget? icon;
   final Color? borderColor;
+  final bool enabled;
 
   const Button({
     super.key,
@@ -26,6 +27,7 @@ class Button extends StatelessWidget {
     this.borderColor,
     this.width,
     this.height,
+    this.enabled = true,
   });
 
   @override
@@ -39,14 +41,17 @@ class Button extends StatelessWidget {
           buttonWidth,
           buttonHeight,
         ),
-        backgroundColor: backgroundColor ?? AppColors.primary,
-        foregroundColor: textColor ?? AppColors.neutralDark,
+        backgroundColor: backgroundColor ??
+            (enabled ? AppColors.primary : AppColors.darkGray),
+        foregroundColor: textColor ??
+            (enabled ? AppColors.neutralDark : AppColors.inputGrey),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(15),
           side: BorderSide(color: borderColor ?? Colors.transparent),
         ),
       ),
-      onPressed: (isLoading || onPressed == null) ? null : onPressed,
+      onPressed:
+          (isLoading || !enabled || onPressed == null) ? null : onPressed,
       child: SizedBox(
         height: buttonHeight,
         child: Center(

--- a/lib/domain/home/components/custom_top_bar.dart
+++ b/lib/domain/home/components/custom_top_bar.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:gachtaxi_app/common/constants/colors.dart';
+import 'package:gachtaxi_app/common/enums/matching_category.dart';
+import 'package:gachtaxi_app/common/util/slide_page_route.dart';
+import 'package:gachtaxi_app/domain/chat/presentation/view/chat_screen.dart';
+import 'package:gachtaxi_app/domain/home/providers/response/auto_matching_status_provider.dart';
 import 'package:gachtaxi_app/domain/home/shared/notifier_icon.dart';
 
 class CustomTopBar extends ConsumerWidget {
@@ -11,6 +15,8 @@ class CustomTopBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final matchingStatusState = ref.watch(autoMatchingStatusNotifierProvider);
+
     return Container(
       padding: EdgeInsets.symmetric(horizontal: 15, vertical: 10),
       decoration: BoxDecoration(
@@ -26,10 +32,51 @@ class CustomTopBar extends ConsumerWidget {
                 width: 32,
                 height: 32,
               ),
-              SizedBox(width: 15),
-              Text(
-                '닉네임',
-                style: TextStyle(color: Colors.white),
+              const SizedBox(width: 15),
+              matchingStatusState.when(
+                data: (res) {
+                  if (res.data != null && res.data!.isFound == true) {
+                    return TextButton(
+                      style: ElevatedButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        textStyle: const TextStyle(fontSize: 16),
+                      ),
+                      onPressed: () async {
+                        await Navigator.push(
+                            context,
+                            SlidePageRoute(
+                                screen: ChatScreen(
+                                    roomId: res.data!.roomId!,
+                                    category: MatchingCategory.auto,
+                                    matchingRoomId:
+                                        res.data!.chattingRoomId!)));
+                        // ignore: unused_result
+                        await ref
+                            // ignore: unused_result
+                            .refresh(autoMatchingStatusNotifierProvider.future);
+                      },
+                      child: const Text("현재 매칭중인 채팅방 입장하기"),
+                    );
+                  } else {
+                    return const Text(
+                      '닉네임',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 16,
+                      ),
+                    );
+                  }
+                },
+                loading: () => const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                      strokeWidth: 2, color: Colors.white),
+                ),
+                error: (err, st) => const Text(
+                  '닉네임',
+                  style: TextStyle(color: Colors.white),
+                ),
               ),
             ],
           ),

--- a/lib/domain/home/model/auto-matching/auto_matching_status_model.dart
+++ b/lib/domain/home/model/auto-matching/auto_matching_status_model.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'auto_matching_status_model.freezed.dart';
+part 'auto_matching_status_model.g.dart';
+
+@freezed
+abstract class AutoMatchingStatusModel with _$AutoMatchingStatusModel {
+  const factory AutoMatchingStatusModel({
+    required bool isFound,
+    int? currentMembers,
+    int? maxCapacity,
+    int? roomId,
+    int? chattingRoomId,
+  }) = _AutoMatchingStatusModel;
+
+  factory AutoMatchingStatusModel.fromJson(Map<String, dynamic> json) =>
+      _$AutoMatchingStatusModelFromJson(json);
+}

--- a/lib/domain/home/providers/request/auto_matching_provider.dart
+++ b/lib/domain/home/providers/request/auto_matching_provider.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:gachtaxi_app/common/model/api_response.dart';
 import 'package:gachtaxi_app/domain/home/model/auto-matching/auto_matching_request_model.dart';
 import 'package:gachtaxi_app/domain/home/services/auto_matching_service_provider.dart';
@@ -19,25 +18,9 @@ class AutoMatching extends _$AutoMatching {
 
     try {
       final res = await service.requestAutoMatching(request);
-      state = AsyncData(res.data);
+      state = AsyncData(res);
     } catch (e, st) {
       state = AsyncError(e, st);
     }
-    // final dummy = ApiResponse(
-    //   data: {
-    //     "autoMatchingStatus": "string",
-    //   },
-    //   message: '하이',
-    //   code: 200,
-    // );
-
-    // try {
-    //   await Future.delayed(const Duration(seconds: 1));
-
-    //   debugPrint('$dummy');
-    //   state = AsyncData(dummy);
-    // } catch (e, st) {
-    //   state = AsyncError(e, st);
-    // }
   }
 }

--- a/lib/domain/home/providers/response/auto_matching_status_provider.dart
+++ b/lib/domain/home/providers/response/auto_matching_status_provider.dart
@@ -1,0 +1,19 @@
+import 'package:gachtaxi_app/common/model/api_response.dart';
+import 'package:gachtaxi_app/domain/home/model/auto-matching/auto_matching_status_model.dart';
+import 'package:gachtaxi_app/domain/home/services/auto_matching_status_service_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auto_matching_status_provider.g.dart';
+
+@riverpod
+class AutoMatchingStatusNotifier extends _$AutoMatchingStatusNotifier {
+  @override
+  Future<ApiResponse<AutoMatchingStatusModel>> build() async {
+    return await _fetchStatus();
+  }
+
+  Future<ApiResponse<AutoMatchingStatusModel>> _fetchStatus() async {
+    final service = ref.read(autoMatchingStatusServiceProvider);
+    return await service.getAutoMatchingStatus();
+  }
+}

--- a/lib/domain/home/services/auto_matching_status_service.dart
+++ b/lib/domain/home/services/auto_matching_status_service.dart
@@ -1,0 +1,22 @@
+import 'package:gachtaxi_app/common/model/api_response.dart';
+import 'package:gachtaxi_app/common/util/api_client.dart';
+import 'package:gachtaxi_app/domain/home/model/auto-matching/auto_matching_status_model.dart';
+
+class AutoMatchingStatusService {
+  Future<ApiResponse<AutoMatchingStatusModel>> getAutoMatchingStatus() async {
+    final path = '/api/matching/auto/status';
+
+    final uri = Uri.parse(path);
+
+    final response = await ApiClient.get(uri);
+
+    if (response.code == 200 && response.data is Map<String, dynamic>) {
+      final statusModel = AutoMatchingStatusModel.fromJson(response.data);
+
+      return ApiResponse(
+          code: response.code, message: response.message, data: statusModel);
+    } else {
+      throw Exception("자동매칭 상태 반환 실패");
+    }
+  }
+}

--- a/lib/domain/home/services/auto_matching_status_service_provider.dart
+++ b/lib/domain/home/services/auto_matching_status_service_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gachtaxi_app/domain/home/services/auto_matching_status_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auto_matching_status_service_provider.g.dart';
+
+@riverpod
+AutoMatchingStatusService autoMatchingStatusService(Ref ref) {
+  return AutoMatchingStatusService();
+}

--- a/lib/domain/home/services/get_current_location_service.dart
+++ b/lib/domain/home/services/get_current_location_service.dart
@@ -20,7 +20,10 @@ class GetCurrentLocationService {
     }
 
     return await Geolocator.getCurrentPosition(
-      desiredAccuracy: LocationAccuracy.best,
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.best,
+        distanceFilter: 0,
+      ),
     );
   }
 }

--- a/lib/domain/matching-waiting/view/matching_waiting_screen.dart
+++ b/lib/domain/matching-waiting/view/matching_waiting_screen.dart
@@ -25,6 +25,7 @@ class MatchingWaitingScreen extends ConsumerStatefulWidget {
 
 class _MatchingWaitingScreenState extends ConsumerState<MatchingWaitingScreen> {
   late final ProviderSubscription _subscription;
+  bool _isMatchingComplete = false;
 
   @override
   void initState() {
@@ -35,6 +36,11 @@ class _MatchingWaitingScreenState extends ConsumerState<MatchingWaitingScreen> {
       (prev, next) async {
         if (next is AsyncData && next.value != null) {
           if (mounted) {
+            setState(() {
+              _isMatchingComplete = true;
+            });
+
+            await Future.delayed(const Duration(milliseconds: 1000));
             try {
               final freshStatus =
                   await ref.refresh(autoMatchingStatusNotifierProvider.future);
@@ -110,40 +116,43 @@ class _MatchingWaitingScreenState extends ConsumerState<MatchingWaitingScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return _buildLoadingScreen();
+    return PopScope(
+      canPop: false,
+      child: _buildLoadingScreen(),
+    );
   }
-}
 
-Widget _buildLoadingScreen() {
-  return DefaultLayout(
-    hasAppBar: false,
-    child: SafeArea(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(
-                '가치 탈 인원을\n 찾는 중이에요!',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: AppTypography.fontSizeExtraLarge,
-                  fontWeight: AppTypography.fontWeightSemibold,
+  Widget _buildLoadingScreen() {
+    return DefaultLayout(
+      hasAppBar: false,
+      child: SafeArea(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  _isMatchingComplete ? '매칭이 완료되었어요!' : '가치 탈 인원을\n 찾는 중이에요!',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: AppTypography.fontSizeExtraLarge,
+                    fontWeight: AppTypography.fontWeightSemibold,
+                  ),
                 ),
-              ),
-              const SizedBox(height: AppSpacing.spaceMedium),
-            ],
-          ),
-          Lottie.asset(
-            'assets/images/taxi_loading.json',
-            width: double.infinity,
-            height: 320,
-          ),
-        ],
+                const SizedBox(height: AppSpacing.spaceMedium),
+              ],
+            ),
+            Lottie.asset(
+              'assets/images/taxi_loading.json',
+              width: double.infinity,
+              height: 320,
+            ),
+          ],
+        ),
       ),
-    ),
-  );
+    );
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련 이슈 번호 #48 
Close #48 


## 🚀 작업 내용
> PR에서 작업한 내용을 설명

- 자동매칭 로직 변경된 부분 적용해 작성했습니다!

- 원래 롱 풀링 방식을 사용하려고 했는데.. 내부의 프로바이더와 위치 가져오기 서비스 사용할 때 생기는 텀도 있고, 요청 보냈을 때 거의 한번에 오는 것 같아서 일단 한번 요청하는걸로 해두었습니다!

- 지금은 자동매칭에 매칭방이 없어서 다른 사람이 만든 방으로 접근 시의 테스트를 하지 못했는데, 가능해지면 나중에 테스트 해보겠습니다!

## 📸 스크린샷


https://github.com/user-attachments/assets/db10bfed-c032-4515-ba1b-5d389c5f1076


## 📢 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

- 자잘한 부분들은 디자인이 따로 나온게 없어서 임의로 해두었는데, (탭 바에 채팅방 이동 버튼 생기는거나 매칭 완료 문구 등) 의견 있으시면 말씀 주세요..!!

- 그리고 가끔 채팅방 들어갔다 다시 나오거나, 매칭 마감 후 이동 시 상태가 최신화되지 않는 (매칭방 나갔는데 매칭중이라고 표시되는 등) 현상이 있는데.. 요청을 보내자마자 바로 상태를 리프레시 하는거라 최신화되지 않은 상태로 받아오는 등 여러가지 상황이 원인이 될 수 있다고 해서 계속 체크해보겠습니다😂

- 채팅방 쪽 UI가 살짝 오버되는 부분이 있습니다! 그리고 마감 눌렀을때 `pop` 되도록해서 스크린 나가는 로직 추가하면 좋을 것 같아요😊